### PR TITLE
Set webcam title from API data

### DIFF
--- a/custom_components/windy_webcams/__init__.py
+++ b/custom_components/windy_webcams/__init__.py
@@ -1,6 +1,8 @@
 """The Windy Webcams integration."""
 from __future__ import annotations
 
+import logging
+
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
@@ -8,7 +10,7 @@ from homeassistant.core import HomeAssistant
 from .const import DOMAIN
 
 PLATFORMS: list[Platform] = [Platform.IMAGE]
-
+_LOGGER = logging.getLogger(__name__)
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Windy Webcams from a config entry."""
@@ -21,6 +23,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
     if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
-        hass.data[DOMAIN].pop(entry.entry_id)
+        try:
+            hass.data[DOMAIN].pop(entry.entry_id)
+        except KeyError:
+            _LOGGER.warning(f"Unable to remove data for config entry with ID {entry.entry_id}. Ignoring.")
 
     return unload_ok

--- a/custom_components/windy_webcams/api.py
+++ b/custom_components/windy_webcams/api.py
@@ -37,6 +37,11 @@ def extract_image_last_updated(json_data):
         return datetime.fromisoformat(str_value)
     return None
 
+def extract_webcam_title(json_data):
+    if 'title' not in json_data:
+        return None
+    return json_data["title"]
+
 
 def get_image_bytes(url):
     response = get(url)

--- a/custom_components/windy_webcams/image.py
+++ b/custom_components/windy_webcams/image.py
@@ -11,6 +11,7 @@ from .api import (
     extract_image_full_url,
     extract_image_last_updated,
     extract_image_preview_url,
+    extract_webcam_title,
     get_image_bytes,
     get_webcam_json_data,
 )
@@ -52,6 +53,14 @@ class WebcamImageEntity(ImageEntity):
         self.image_last_updated = extract_image_last_updated(json)
         self.async_write_ha_state()
         return data
+
+    async def async_added_to_hass(self):
+        """Run when the entity is added to Home Assistant."""
+        json = await self.hass.async_add_executor_job(self._get_webcam_data_json)
+        webcam_name = extract_webcam_title(json)
+
+        if (webcam_name):
+            self._attr_name = webcam_name
 
 
 async def async_setup_entry(


### PR DESCRIPTION
This change adds logic to set the name of the webcam entities to the `title` attribute from the API response. This makes it easier to distinguish between entities.